### PR TITLE
Fix version output and help messages after rebranding

### DIFF
--- a/cmd/frostfs-adm/internal/modules/morph/root.go
+++ b/cmd/frostfs-adm/internal/modules/morph/root.go
@@ -108,7 +108,7 @@ var (
 
 	forceNewEpoch = &cobra.Command{
 		Use:   "force-new-epoch",
-		Short: "Create new NeoFS epoch event in the side chain",
+		Short: "Create new FrostFS epoch event in the side chain",
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			_ = viper.BindPFlag(alphabetWalletsFlag, cmd.Flags().Lookup(alphabetWalletsFlag))
 			_ = viper.BindPFlag(endpointFlag, cmd.Flags().Lookup(endpointFlag))
@@ -130,7 +130,7 @@ var (
 	setConfig = &cobra.Command{
 		Use:                   "set-config key1=val1 [key2=val2 ...]",
 		DisableFlagsInUseLine: true,
-		Short:                 "Add/update global config value in the NeoFS network",
+		Short:                 "Add/update global config value in the FrostFS network",
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			_ = viper.BindPFlag(alphabetWalletsFlag, cmd.Flags().Lookup(alphabetWalletsFlag))
 			_ = viper.BindPFlag(endpointFlag, cmd.Flags().Lookup(endpointFlag))
@@ -164,7 +164,7 @@ var (
 
 	dumpNetworkConfigCmd = &cobra.Command{
 		Use:   "dump-config",
-		Short: "Dump NeoFS network config",
+		Short: "Dump FrostFS network config",
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			_ = viper.BindPFlag(endpointFlag, cmd.Flags().Lookup(endpointFlag))
 		},
@@ -182,7 +182,7 @@ var (
 
 	updateContractsCmd = &cobra.Command{
 		Use:   "update-contracts",
-		Short: "Update NeoFS contracts",
+		Short: "Update FrostFS contracts",
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			_ = viper.BindPFlag(alphabetWalletsFlag, cmd.Flags().Lookup(alphabetWalletsFlag))
 			_ = viper.BindPFlag(endpointFlag, cmd.Flags().Lookup(endpointFlag))
@@ -192,7 +192,7 @@ var (
 
 	dumpContainersCmd = &cobra.Command{
 		Use:   "dump-containers",
-		Short: "Dump NeoFS containers to file",
+		Short: "Dump FrostFS containers to file",
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			_ = viper.BindPFlag(endpointFlag, cmd.Flags().Lookup(endpointFlag))
 		},
@@ -201,7 +201,7 @@ var (
 
 	restoreContainersCmd = &cobra.Command{
 		Use:   "restore-containers",
-		Short: "Restore NeoFS containers from file",
+		Short: "Restore FrostFS containers from file",
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			_ = viper.BindPFlag(alphabetWalletsFlag, cmd.Flags().Lookup(alphabetWalletsFlag))
 			_ = viper.BindPFlag(endpointFlag, cmd.Flags().Lookup(endpointFlag))
@@ -211,7 +211,7 @@ var (
 
 	listContainersCmd = &cobra.Command{
 		Use:   "list-containers",
-		Short: "List NeoFS containers",
+		Short: "List FrostFS containers",
 		PreRun: func(cmd *cobra.Command, _ []string) {
 			_ = viper.BindPFlag(endpointFlag, cmd.Flags().Lookup(endpointFlag))
 		},
@@ -236,8 +236,8 @@ func init() {
 	RootCmd.AddCommand(initCmd)
 	initCmd.Flags().String(alphabetWalletsFlag, "", "Path to alphabet wallets dir")
 	initCmd.Flags().StringP(endpointFlag, "r", "", "N3 RPC node endpoint")
-	initCmd.Flags().String(contractsInitFlag, "", "Path to archive with compiled NeoFS contracts (default fetched from latest github release)")
-	initCmd.Flags().Uint(epochDurationCLIFlag, 240, "Amount of side chain blocks in one NeoFS epoch")
+	initCmd.Flags().String(contractsInitFlag, "", "Path to archive with compiled FrostFS contracts (default fetched from latest github release)")
+	initCmd.Flags().Uint(epochDurationCLIFlag, 240, "Amount of side chain blocks in one FrostFS epoch")
 	initCmd.Flags().Uint(maxObjectSizeCLIFlag, 67108864, "Max single object size in bytes")
 	initCmd.Flags().Bool(homomorphicHashDisabledCLIFlag, false, "Disable object homomorphic hashing")
 	// Defaults are taken from neo-preodolenie.
@@ -289,7 +289,7 @@ func init() {
 	RootCmd.AddCommand(updateContractsCmd)
 	updateContractsCmd.Flags().String(alphabetWalletsFlag, "", "Path to alphabet wallets dir")
 	updateContractsCmd.Flags().StringP(endpointFlag, "r", "", "N3 RPC node endpoint")
-	updateContractsCmd.Flags().String(contractsInitFlag, "", "Path to archive with compiled NeoFS contracts (default fetched from latest github release)")
+	updateContractsCmd.Flags().String(contractsInitFlag, "", "Path to archive with compiled FrostFS contracts (default fetched from latest github release)")
 
 	RootCmd.AddCommand(dumpContainersCmd)
 	dumpContainersCmd.Flags().StringP(endpointFlag, "r", "", "N3 RPC node endpoint")

--- a/cmd/frostfs-adm/internal/modules/morph/subnet.go
+++ b/cmd/frostfs-adm/internal/modules/morph/subnet.go
@@ -39,7 +39,7 @@ func viperBindFlags(cmd *cobra.Command, flags ...string) {
 // subnet command section.
 var cmdSubnet = &cobra.Command{
 	Use:   "subnet",
-	Short: "NeoFS subnet management",
+	Short: "FrostFS subnet management",
 	PreRun: func(cmd *cobra.Command, _ []string) {
 		viperBindFlags(cmd,
 			endpointFlag,
@@ -112,7 +112,7 @@ func readSubnetKey(key *keys.PrivateKey) error {
 // create subnet command.
 var cmdSubnetCreate = &cobra.Command{
 	Use:   "create",
-	Short: "Create NeoFS subnet",
+	Short: "Create FrostFS subnet",
 	PreRun: func(cmd *cobra.Command, _ []string) {
 		viperBindFlags(cmd,
 			flagSubnetWallet,
@@ -177,7 +177,7 @@ var errZeroSubnet = errors.New("zero subnet")
 // remove subnet command.
 var cmdSubnetRemove = &cobra.Command{
 	Use:   "remove",
-	Short: "Remove NeoFS subnet",
+	Short: "Remove FrostFS subnet",
 	PreRun: func(cmd *cobra.Command, _ []string) {
 		viperBindFlags(cmd,
 			flagSubnetWallet,
@@ -226,7 +226,7 @@ const (
 // get subnet command.
 var cmdSubnetGet = &cobra.Command{
 	Use:   "get",
-	Short: "Read information about the NeoFS subnet",
+	Short: "Read information about the FrostFS subnet",
 	PreRun: func(cmd *cobra.Command, _ []string) {
 		viperBindFlags(cmd,
 			flagSubnetGetID,
@@ -290,7 +290,7 @@ const (
 // command to manage subnet admins.
 var cmdSubnetAdmin = &cobra.Command{
 	Use:   "admin",
-	Short: "Manage administrators of the NeoFS subnet",
+	Short: "Manage administrators of the FrostFS subnet",
 	PreRun: func(cmd *cobra.Command, args []string) {
 		viperBindFlags(cmd,
 			flagSubnetWallet,
@@ -397,7 +397,7 @@ func manageSubnetAdmins(cmd *cobra.Command, rm bool) error {
 // command to add subnet admin.
 var cmdSubnetAdminAdd = &cobra.Command{
 	Use:   "add",
-	Short: "Add admin to the NeoFS subnet",
+	Short: "Add admin to the FrostFS subnet",
 	PreRun: func(cmd *cobra.Command, _ []string) {
 		viperBindFlags(cmd,
 			flagSubnetAdminAddGroup,
@@ -412,7 +412,7 @@ var cmdSubnetAdminAdd = &cobra.Command{
 // command to remove subnet admin.
 var cmdSubnetAdminRemove = &cobra.Command{
 	Use:   "remove",
-	Short: "Remove admin of the NeoFS subnet",
+	Short: "Remove admin of the FrostFS subnet",
 	PreRun: func(cmd *cobra.Command, _ []string) {
 		viperBindFlags(cmd,
 			flagSubnetAdminClient,
@@ -433,7 +433,7 @@ const (
 // command to manage subnet clients.
 var cmdSubnetClient = &cobra.Command{
 	Use:   "client",
-	Short: "Manage clients of the NeoFS subnet",
+	Short: "Manage clients of the FrostFS subnet",
 	PreRun: func(cmd *cobra.Command, _ []string) {
 		viperBindFlags(cmd,
 			flagSubnetWallet,
@@ -516,7 +516,7 @@ func manageSubnetClients(cmd *cobra.Command, rm bool) error {
 // command to add subnet client.
 var cmdSubnetClientAdd = &cobra.Command{
 	Use:   "add",
-	Short: "Add client to the NeoFS subnet",
+	Short: "Add client to the FrostFS subnet",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		return manageSubnetClients(cmd, false)
 	},
@@ -525,7 +525,7 @@ var cmdSubnetClientAdd = &cobra.Command{
 // command to remove subnet client.
 var cmdSubnetClientRemove = &cobra.Command{
 	Use:   "remove",
-	Short: "Remove client of the NeoFS subnet",
+	Short: "Remove client of the FrostFS subnet",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		return manageSubnetClients(cmd, true)
 	},
@@ -598,7 +598,7 @@ func manageSubnetNodes(cmd *cobra.Command, rm bool) error {
 // command to manage subnet nodes.
 var cmdSubnetNode = &cobra.Command{
 	Use:   "node",
-	Short: "Manage nodes of the NeoFS subnet",
+	Short: "Manage nodes of the FrostFS subnet",
 	PreRun: func(cmd *cobra.Command, _ []string) {
 		viperBindFlags(cmd,
 			flagSubnetWallet,
@@ -611,7 +611,7 @@ var cmdSubnetNode = &cobra.Command{
 // command to add subnet node.
 var cmdSubnetNodeAdd = &cobra.Command{
 	Use:   "add",
-	Short: "Add node to the NeoFS subnet",
+	Short: "Add node to the FrostFS subnet",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		return manageSubnetNodes(cmd, false)
 	},
@@ -620,7 +620,7 @@ var cmdSubnetNodeAdd = &cobra.Command{
 // command to remove subnet node.
 var cmdSubnetNodeRemove = &cobra.Command{
 	Use:   "remove",
-	Short: "Remove node from the NeoFS subnet",
+	Short: "Remove node from the FrostFS subnet",
 	RunE: func(cmd *cobra.Command, _ []string) error {
 		return manageSubnetNodes(cmd, true)
 	},
@@ -693,7 +693,7 @@ func init() {
 	_ = cmdSubnetClient.MarkFlagRequired(flagSubnetClientSubnet)
 	clientFlags.String(flagSubnetClientGroup, "", "ID of the client group to work with")
 	_ = cmdSubnetClient.MarkFlagRequired(flagSubnetClientGroup)
-	clientFlags.String(flagSubnetClientID, "", "Client's user ID in NeoFS system in text format")
+	clientFlags.String(flagSubnetClientID, "", "Client's user ID in FrostFS system in text format")
 	_ = cmdSubnetClient.MarkFlagRequired(flagSubnetClientID)
 	clientFlags.StringP(flagSubnetWallet, "w", "", "Path to file with wallet")
 	_ = cmdSubnetClient.MarkFlagRequired(flagSubnetWallet)

--- a/cmd/frostfs-adm/internal/modules/root.go
+++ b/cmd/frostfs-adm/internal/modules/root.go
@@ -16,9 +16,9 @@ import (
 var (
 	rootCmd = &cobra.Command{
 		Use:   "frostfs-adm",
-		Short: "NeoFS Administrative Tool",
-		Long: `NeoFS Administrative Tool provides functions to setup and
-manage NeoFS network deployment.`,
+		Short: "FrostFS Administrative Tool",
+		Long: `FrostFS Administrative Tool provides functions to setup and
+manage FrostFS network deployment.`,
 		RunE:         entryPoint,
 		SilenceUsage: true,
 	}

--- a/cmd/frostfs-adm/internal/modules/root.go
+++ b/cmd/frostfs-adm/internal/modules/root.go
@@ -52,7 +52,7 @@ func Execute() error {
 func entryPoint(cmd *cobra.Command, args []string) error {
 	printVersion, _ := cmd.Flags().GetBool("version")
 	if printVersion {
-		cmd.Print(misc.BuildInfo("NeoFS Adm"))
+		cmd.Print(misc.BuildInfo("FrostFS Adm"))
 		return nil
 	}
 

--- a/cmd/frostfs-adm/internal/modules/storagecfg/config.go
+++ b/cmd/frostfs-adm/internal/modules/storagecfg/config.go
@@ -14,7 +14,7 @@ node:
   relay: {{ .Relay }}  # start Storage node in relay mode without bootstrapping into the Network map
   subnet:
     exit_zero: false # toggle entrance to zero subnet (overrides corresponding attribute and occurrence in entries)
-    entries: [] # list of IDs of subnets to enter in a text format of NeoFS API protocol (overrides corresponding attributes)
+    entries: [] # list of IDs of subnets to enter in a text format of FrostFS API protocol (overrides corresponding attributes)
 
 grpc:
   num: 1  # total number of listener endpoints

--- a/cmd/frostfs-cli/modules/accounting/balance.go
+++ b/cmd/frostfs-cli/modules/accounting/balance.go
@@ -21,8 +21,8 @@ const (
 
 var accountingBalanceCmd = &cobra.Command{
 	Use:   "balance",
-	Short: "Get internal balance of NeoFS account",
-	Long:  `Get internal balance of NeoFS account`,
+	Short: "Get internal balance of FrostFS account",
+	Long:  `Get internal balance of FrostFS account`,
 	Run: func(cmd *cobra.Command, args []string) {
 		var idUser user.ID
 

--- a/cmd/frostfs-cli/modules/container/create.go
+++ b/cmd/frostfs-cli/modules/container/create.go
@@ -33,7 +33,7 @@ var (
 var createContainerCmd = &cobra.Command{
 	Use:   "create",
 	Short: "Create new container",
-	Long: `Create new container and register it in the NeoFS. 
+	Long: `Create new container and register it in the FrostFS. 
 It will be stored in sidechain when inner ring will accepts it.`,
 	Run: func(cmd *cobra.Command, args []string) {
 		placementPolicy, err := parseContainerPolicy(cmd, containerPolicy)

--- a/cmd/frostfs-cli/modules/control/healthcheck.go
+++ b/cmd/frostfs-cli/modules/control/healthcheck.go
@@ -19,8 +19,8 @@ const (
 
 var healthCheckCmd = &cobra.Command{
 	Use:   "healthcheck",
-	Short: "Health check of the NeoFS node",
-	Long:  "Health check of the NeoFS node. Checks storage node by default, use --ir flag to work with Inner Ring.",
+	Short: "Health check of the FrostFS node",
+	Long:  "Health check of the FrostFS node. Checks storage node by default, use --ir flag to work with Inner Ring.",
 	Run:   healthCheck,
 }
 

--- a/cmd/frostfs-cli/modules/control/set_netmap_status.go
+++ b/cmd/frostfs-cli/modules/control/set_netmap_status.go
@@ -21,8 +21,8 @@ const (
 
 var setNetmapStatusCmd = &cobra.Command{
 	Use:   "set-status",
-	Short: "Set status of the storage node in NeoFS network map",
-	Long:  "Set status of the storage node in NeoFS network map",
+	Short: "Set status of the storage node in FrostFS network map",
+	Long:  "Set status of the storage node in FrostFS network map",
 	Run:   setNetmapStatus,
 }
 

--- a/cmd/frostfs-cli/modules/netmap/netinfo.go
+++ b/cmd/frostfs-cli/modules/netmap/netinfo.go
@@ -14,8 +14,8 @@ import (
 
 var netInfoCmd = &cobra.Command{
 	Use:   "netinfo",
-	Short: "Get information about NeoFS network",
-	Long:  "Get information about NeoFS network",
+	Short: "Get information about FrostFS network",
+	Long:  "Get information about FrostFS network",
 	Run: func(cmd *cobra.Command, args []string) {
 		p := key.GetOrGenerate(cmd)
 		cli := internalclient.GetSDKClientByFlag(cmd, p, commonflags.RPC)

--- a/cmd/frostfs-cli/modules/object/delete.go
+++ b/cmd/frostfs-cli/modules/object/delete.go
@@ -15,8 +15,8 @@ import (
 var objectDelCmd = &cobra.Command{
 	Use:     "delete",
 	Aliases: []string{"del"},
-	Short:   "Delete object from NeoFS",
-	Long:    "Delete object from NeoFS",
+	Short:   "Delete object from FrostFS",
+	Long:    "Delete object from FrostFS",
 	Run:     deleteObject,
 }
 

--- a/cmd/frostfs-cli/modules/object/get.go
+++ b/cmd/frostfs-cli/modules/object/get.go
@@ -19,8 +19,8 @@ import (
 
 var objectGetCmd = &cobra.Command{
 	Use:   "get",
-	Short: "Get object from NeoFS",
-	Long:  "Get object from NeoFS",
+	Short: "Get object from FrostFS",
+	Long:  "Get object from FrostFS",
 	Run:   getObject,
 }
 
@@ -115,7 +115,7 @@ func getObject(cmd *cobra.Command, _ []string) {
 
 	if binary {
 		objToStore := res.Header()
-		//TODO(@acid-ant): #1932 Use streams to marshal/unmarshal payload
+		// TODO(@acid-ant): #1932 Use streams to marshal/unmarshal payload
 		objToStore.SetPayload(payloadBuffer.Bytes())
 		objBytes, err := objToStore.Marshal()
 		common.ExitOnErr(cmd, "", err)

--- a/cmd/frostfs-cli/modules/object/put.go
+++ b/cmd/frostfs-cli/modules/object/put.go
@@ -31,8 +31,8 @@ var putExpiredOn uint64
 
 var objectPutCmd = &cobra.Command{
 	Use:   "put",
-	Short: "Put object to NeoFS",
-	Long:  "Put object to NeoFS",
+	Short: "Put object to FrostFS",
+	Long:  "Put object to FrostFS",
 	Run:   putObject,
 }
 
@@ -82,7 +82,7 @@ func putObject(cmd *cobra.Command, _ []string) {
 		buf, err := os.ReadFile(filename)
 		common.ExitOnErr(cmd, "unable to read given file: %w", err)
 		objTemp := object.New()
-		//TODO(@acid-ant): #1932 Use streams to marshal/unmarshal payload
+		// TODO(@acid-ant): #1932 Use streams to marshal/unmarshal payload
 		common.ExitOnErr(cmd, "can't unmarshal object from given file: %w", objTemp.Unmarshal(buf))
 		payloadReader = bytes.NewReader(objTemp.Payload())
 		cnr, _ = objTemp.ContainerID()

--- a/cmd/frostfs-cli/modules/root.go
+++ b/cmd/frostfs-cli/modules/root.go
@@ -89,7 +89,7 @@ func init() {
 func entryPoint(cmd *cobra.Command, _ []string) {
 	printVersion, _ := cmd.Flags().GetBool("version")
 	if printVersion {
-		cmd.Print(misc.BuildInfo("NeoFS CLI"))
+		cmd.Print(misc.BuildInfo("FrostFS CLI"))
 
 		return
 	}

--- a/cmd/frostfs-cli/modules/root.go
+++ b/cmd/frostfs-cli/modules/root.go
@@ -36,10 +36,10 @@ var (
 // rootCmd represents the base command when called without any subcommands.
 var rootCmd = &cobra.Command{
 	Use:   "frostfs-cli",
-	Short: "Command Line Tool to work with NeoFS",
-	Long: `NeoFS CLI provides all basic interactions with NeoFS and it's services.
+	Short: "Command Line Tool to work with FrostFS",
+	Long: `FrostFS CLI provides all basic interactions with FrostFS and it's services.
 
-It contains commands for interaction with NeoFS nodes using different versions
+It contains commands for interaction with FrostFS nodes using different versions
 of frostfs-api and some useful utilities for compiling ACL rules from JSON
 notation, managing container access through protocol gates, querying network map
 and much more!`,
@@ -70,7 +70,7 @@ func init() {
 
 	// Cobra also supports local flags, which will only run
 	// when this action is called directly.
-	rootCmd.Flags().Bool("version", false, "Application version and NeoFS API compatibility")
+	rootCmd.Flags().Bool("version", false, "Application version and FrostFS API compatibility")
 
 	rootCmd.AddCommand(acl.Cmd)
 	rootCmd.AddCommand(bearerCli.Cmd)

--- a/cmd/frostfs-cli/modules/storagegroup/delete.go
+++ b/cmd/frostfs-cli/modules/storagegroup/delete.go
@@ -13,8 +13,8 @@ import (
 
 var sgDelCmd = &cobra.Command{
 	Use:   "delete",
-	Short: "Delete storage group from NeoFS",
-	Long:  "Delete storage group from NeoFS",
+	Short: "Delete storage group from FrostFS",
+	Long:  "Delete storage group from FrostFS",
 	Run:   delSG,
 }
 

--- a/cmd/frostfs-cli/modules/storagegroup/get.go
+++ b/cmd/frostfs-cli/modules/storagegroup/get.go
@@ -18,8 +18,8 @@ var sgID string
 
 var sgGetCmd = &cobra.Command{
 	Use:   "get",
-	Short: "Get storage group from NeoFS",
-	Long:  "Get storage group from NeoFS",
+	Short: "Get storage group from FrostFS",
+	Long:  "Get storage group from FrostFS",
 	Run:   getSG,
 }
 

--- a/cmd/frostfs-cli/modules/storagegroup/list.go
+++ b/cmd/frostfs-cli/modules/storagegroup/list.go
@@ -13,8 +13,8 @@ import (
 
 var sgListCmd = &cobra.Command{
 	Use:   "list",
-	Short: "List storage groups in NeoFS container",
-	Long:  "List storage groups in NeoFS container",
+	Short: "List storage groups in FrostFS container",
+	Long:  "List storage groups in FrostFS container",
 	Run:   listSG,
 }
 

--- a/cmd/frostfs-cli/modules/storagegroup/put.go
+++ b/cmd/frostfs-cli/modules/storagegroup/put.go
@@ -26,8 +26,8 @@ var sgMembers []string
 
 var sgPutCmd = &cobra.Command{
 	Use:   "put",
-	Short: "Put storage group to NeoFS",
-	Long:  "Put storage group to NeoFS",
+	Short: "Put storage group to FrostFS",
+	Long:  "Put storage group to FrostFS",
 	Run:   putSG,
 }
 

--- a/cmd/frostfs-cli/modules/util/convert.go
+++ b/cmd/frostfs-cli/modules/util/convert.go
@@ -4,7 +4,7 @@ import "github.com/spf13/cobra"
 
 var convertCmd = &cobra.Command{
 	Use:   "convert",
-	Short: "Convert representation of NeoFS structures",
+	Short: "Convert representation of FrostFS structures",
 }
 
 func initConvertCmd() {

--- a/cmd/frostfs-cli/modules/util/locode.go
+++ b/cmd/frostfs-cli/modules/util/locode.go
@@ -7,7 +7,7 @@ import (
 // locode section.
 var locodeCmd = &cobra.Command{
 	Use:   "locode",
-	Short: "Working with NeoFS UN/LOCODE database",
+	Short: "Working with FrostFS UN/LOCODE database",
 }
 
 func initLocodeCmd() {

--- a/cmd/frostfs-cli/modules/util/locode_generate.go
+++ b/cmd/frostfs-cli/modules/util/locode_generate.go
@@ -34,7 +34,7 @@ var (
 
 	locodeGenerateCmd = &cobra.Command{
 		Use:   "generate",
-		Short: "Generate UN/LOCODE database for NeoFS",
+		Short: "Generate UN/LOCODE database for FrostFS",
 		Run: func(cmd *cobra.Command, _ []string) {
 			locodeDB := csvlocode.New(
 				csvlocode.Prm{

--- a/cmd/frostfs-cli/modules/util/locode_info.go
+++ b/cmd/frostfs-cli/modules/util/locode_info.go
@@ -18,7 +18,7 @@ var (
 
 	locodeInfoCmd = &cobra.Command{
 		Use:   "info",
-		Short: "Print information about UN/LOCODE from NeoFS database",
+		Short: "Print information about UN/LOCODE from FrostFS database",
 		Run: func(cmd *cobra.Command, _ []string) {
 			targetDB := locodebolt.New(locodebolt.Prm{
 				Path: locodeInfoDBPath,
@@ -48,7 +48,7 @@ var (
 func initUtilLocodeInfoCmd() {
 	flags := locodeInfoCmd.Flags()
 
-	flags.StringVar(&locodeInfoDBPath, locodeInfoDBFlag, "", "Path to NeoFS UN/LOCODE database")
+	flags.StringVar(&locodeInfoDBPath, locodeInfoDBFlag, "", "Path to FrostFS UN/LOCODE database")
 	_ = locodeInfoCmd.MarkFlagRequired(locodeInfoDBFlag)
 
 	flags.StringVar(&locodeInfoCode, locodeInfoCodeFlag, "", "UN/LOCODE")

--- a/cmd/frostfs-cli/modules/util/sign.go
+++ b/cmd/frostfs-cli/modules/util/sign.go
@@ -11,7 +11,7 @@ const (
 
 var signCmd = &cobra.Command{
 	Use:   "sign",
-	Short: "Sign NeoFS structure",
+	Short: "Sign FrostFS structure",
 }
 
 func initSignCmd() {

--- a/cmd/frostfs-ir/main.go
+++ b/cmd/frostfs-ir/main.go
@@ -39,7 +39,7 @@ func main() {
 	flag.Parse()
 
 	if *versionFlag {
-		fmt.Print(misc.BuildInfo("NeoFS Inner Ring node"))
+		fmt.Print(misc.BuildInfo("FrostFS Inner Ring node"))
 
 		os.Exit(SuccessReturnCode)
 	}

--- a/cmd/frostfs-lens/root.go
+++ b/cmd/frostfs-lens/root.go
@@ -13,8 +13,8 @@ import (
 
 var command = &cobra.Command{
 	Use:          "frostfs-lens",
-	Short:        "NeoFS Storage Engine Lens",
-	Long:         `NeoFS Storage Engine Lens provides tools to browse the contents of the NeoFS storage engine.`,
+	Short:        "FrostFS Storage Engine Lens",
+	Long:         `FrostFS Storage Engine Lens provides tools to browse the contents of the FrostFS storage engine.`,
 	RunE:         entryPoint,
 	SilenceUsage: true,
 }

--- a/cmd/frostfs-lens/root.go
+++ b/cmd/frostfs-lens/root.go
@@ -22,7 +22,7 @@ var command = &cobra.Command{
 func entryPoint(cmd *cobra.Command, _ []string) error {
 	printVersion, _ := cmd.Flags().GetBool("version")
 	if printVersion {
-		cmd.Print(misc.BuildInfo("NeoFS Lens"))
+		cmd.Print(misc.BuildInfo("FrostFS Lens"))
 
 		return nil
 	}

--- a/cmd/frostfs-node/main.go
+++ b/cmd/frostfs-node/main.go
@@ -41,7 +41,7 @@ func main() {
 	flag.Parse()
 
 	if *versionFlag {
-		fmt.Print(misc.BuildInfo("NeoFS Storage node"))
+		fmt.Print(misc.BuildInfo("FrostFS Storage node"))
 
 		os.Exit(SuccessReturnCode)
 	}


### PR DESCRIPTION
Related to #1 

- Updates output of `--version` for all binaries
- Updates help messages of the cobra applications (CLI, Adm, Lens)