### PR TITLE
cli: Set flag `mode` required for `control shards set-mode`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ Changelog for FrostFS Node
 - Fetching blobovnicza objects that not found in write-cache (#2206)
 - Do not search for the small objects in FSTree (#2206)
 - Correct status error for expired session token (#2207)
+- Set flag `mode` required for `frostfs-cli control shards set-mode` (#8)
 
 ### Removed
 ### Updated

--- a/cmd/frostfs-cli/modules/control/shards_set_mode.go
+++ b/cmd/frostfs-cli/modules/control/shards_set_mode.go
@@ -93,6 +93,7 @@ func initControlSetShardModeCmd() {
 	flags.String(shardModeFlag, "",
 		fmt.Sprintf("New shard mode (%s)", strings.Join(modes, ", ")),
 	)
+	_ = setShardModeCmd.MarkFlagRequired(shardModeFlag)
 	flags.Bool(shardClearErrorsFlag, false, "Set shard error count to 0")
 
 	setShardModeCmd.MarkFlagsMutuallyExclusive(shardIDFlag, shardAllFlag)


### PR DESCRIPTION
Close #8

Example error output:
```
@:~/workspace/neofs-node$ frostfs-cli control shards set-mode --clear-errors --all -w ../neofs-dev-env/wallets/wallet.json --endpoint  localhost:8091
Error: required flag(s) "mode" not set
Usage:
  frostfs-cli control shards set-mode [flags]
...
required flag(s) "mode" not set
@:~/workspace/neofs-node$
```

Signed-off-by: Anton Nikiforov <an.nikiforov@yadro.com>