### PR TITLE
[#53] Fix dirty in version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -30,5 +30,22 @@ testfile
 .neofs-cli.yml
 
 # debhelpers
-**/.debhelper
+debian/*debhelper*
+
+# logfiles
+debian/*.log
+
+# .substvars
+debian/*.substvars
+
+# .bash-completion
+debian/*.bash-completion
+
+# Install folders and files
+debian/frostfs-cli/
+debian/frostfs-ir/
+debian/files
+debian/frostfs-storage/
 debian/changelog
+man/
+debs/

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ Changelog for FrostFS Node
 - Do not search for the small objects in FSTree (#2206)
 - Correct status error for expired session token (#2207)
 - Set flag `mode` required for `frostfs-cli control shards set-mode` (#8)
+- Fix `dirty` suffix in debian package version (#53)
 
 ### Removed
 ### Updated


### PR DESCRIPTION
Now after build debian package, we see "dirty" suffix in version, example:
```
neofs-node --version
NeoFS Storage node
Version: v0.35.0-43-g3209d746-dirty
GoVersion: go1.18.4
```

It's happens because ```make debpackage``` download all dependencies in work directory, and after download git directory have uncommited changes. All changes are placed in debian folder and i'm solve this problem after add this files in .gitignore

Signed-off-by: Aleksey Pastukhov <a.pastukhov@yadro.com>